### PR TITLE
Update Mercurial to version 3.9.2

### DIFF
--- a/hg/tarmaker/mercurial/mercurial.hash
+++ b/hg/tarmaker/mercurial/mercurial.hash
@@ -1,1 +1,1 @@
-sha256 5ba9438d6ab0db93f7b0786ba632138eb64a9dc0d93e30dde2b17b328fdc6d7a  mercurial-3.7.2.tar.gz
+sha256 69046a427c05e83097bf0145a1e37975ae0b6ba4430456e2beca3d2fd96583cf  mercurial-3.9.2.tar.gz

--- a/hg/tarmaker/mercurial/mercurial.mk
+++ b/hg/tarmaker/mercurial/mercurial.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-MERCURIAL_VERSION = 3.7.2
+MERCURIAL_VERSION = 3.9.2
 MERCURIAL_SOURCE = mercurial-$(MERCURIAL_VERSION).tar.gz
 MERCURIAL_SITE = https://www.mercurial-scm.org/release
 MERCURIAL_LICENSE = GPLv2


### PR DESCRIPTION
There are [CVEs that are fixed in mercurial 3.7.3](https://www.mercurial-scm.org/wiki/WhatsNew#Mercurial_3.7.3_.282016-3-29.29), but the latest version of mercurial passes all tests in [hg-resource](https://github.com/concourse/hg-resource).
