### PR TITLE
Disable publish on incoming changesets

### DIFF
--- a/hg/hgrc
+++ b/hg/hgrc
@@ -1,2 +1,5 @@
 [ui]
 username = User Name <user@example.com>
+
+[phases]
+publish = false


### PR DESCRIPTION
By default, the draft changesets from the remote repository have their
phase changed to 'public' localy.

It is a problem when we want to filter out draft changesets.

Adding phases.publish=false to hgrc will make mercurial preserve the
changeset phase.